### PR TITLE
Move Clustering and Feature Extraction models into factory selectors 

### DIFF
--- a/spike_cluster_gmm_skl.py
+++ b/spike_cluster_gmm_skl.py
@@ -7,14 +7,15 @@ from pyspark import SparkContext, SparkConf
 from pyspark.sql import functions as F
 from math import sqrt
 from sklearn import mixture
+from spike_cluster_type import SpikeClustering
 
-class SpikeClusterGMM(object):
+class SpikeClusterGMM_SKL(SpikeClustering):
 
   def __init__(self, spark):
     self.sp = spark
 
   # Fit into Gaussian Mixture Model
-  def GMM(self, waveforms, k=3, max_iter=20):
+  def Cluster(self, waveforms, k=3, max_iter=20):
 
     gmm = mixture.GaussianMixture(n_components=k, max_iter=max_iter)
     gmm.fit(waveforms)

--- a/spike_cluster_kmeans.py
+++ b/spike_cluster_kmeans.py
@@ -6,8 +6,9 @@ from pyspark.sql import *
 from pyspark import SparkContext, SparkConf
 from pyspark.sql import functions as F
 from math import sqrt
+from spike_cluster_type import SpikeClustering
 
-class SpikeClusterKMeans(object):
+class SpikeClusterKMeans(SpikeClustering):
 
   def __init__(self, spark):
     self.sp = spark
@@ -56,7 +57,7 @@ class SpikeClusterKMeans(object):
     return (new_cluster, (ret, 1))
 
   # Implement k-means
-  def KMeans(self, waveforms, k=3, max_iter=20):
+  def Cluster(self, waveforms, k=3, max_iter=20):
 
     # for initialization, we randomly select k centroids
     centroids = [None] * k

--- a/spike_cluster_kmeans_mllib.py
+++ b/spike_cluster_kmeans_mllib.py
@@ -10,8 +10,9 @@ from math import sqrt
 
 from pyspark.ml.clustering import KMeans
 from pyspark.ml.evaluation import ClusteringEvaluator
+from spike_cluster_type import SpikeClustering
 
-class SpikeClusterKMeans_MLLib(object):
+class SpikeClusterKMeans_MLLib(SpikeClustering):
 
   def __init__(self, spark):
     self.sp = spark
@@ -23,7 +24,7 @@ class SpikeClusterKMeans_MLLib(object):
     return (model.predict(point), (sum([x**2 for x in (point - center)]), 1))
 
   # Implement k-means
-  def KMeans(self, waveforms, k=3, max_iter=20):
+  def Cluster(self, waveforms, k=3, max_iter=20):
     list_data = [(Vectors.dense(form.tolist()),) for form in waveforms]
 
     # Loads data.

--- a/spike_cluster_kmeans_skl.py
+++ b/spike_cluster_kmeans_skl.py
@@ -1,0 +1,29 @@
+import logging
+import numpy as np
+import random
+
+from pyspark.sql import *
+from pyspark import SparkContext, SparkConf
+from pyspark.sql import functions as F
+from math import sqrt
+from sklearn.cluster import KMeans
+from spike_cluster_type import SpikeClustering
+
+class SpikeClusterKmeans_SKL(SpikeClustering):
+
+  def __init__(self, spark):
+    self.sp = spark
+
+  # Fit into Gaussian Mixture Model
+  def Cluster(self, waveforms, k=3, max_iter=20):
+
+    km = KMeans(n_clusters=k, max_iter=max_iter)
+    km.fit(waveforms)
+    labels = km.labels_
+
+    clusters = [ [] for _ in range(k) ]
+
+    for idx in range(k):
+      clusters[idx] = [i for i in range(len(labels)) if labels[i] == idx]
+
+    return clusters

--- a/spike_cluster_type.py
+++ b/spike_cluster_type.py
@@ -1,0 +1,17 @@
+
+import logging
+import numpy as np
+
+from pyspark.sql import *
+from pyspark import SparkContext, SparkConf
+from pyspark.sql import functions as F
+from math import sqrt
+
+class SpikeClustering(object):
+
+  def __init__(self):
+    pass
+
+  @classmethod
+  def Cluster(self, data, k=3, max_iter=20):
+    pass

--- a/spike_fe.py
+++ b/spike_fe.py
@@ -6,13 +6,14 @@ from pyspark.sql import *
 from pyspark import SparkContext, SparkConf
 from pyspark.sql import functions as F
 from math import sqrt
+from spike_fe_type import SpikeFeatureExtract
 
-class SpikeFeatureExtractPCA(object):
+class SpikeFeatureExtractPCA(SpikeFeatureExtract):
 
   def __init__(self, spark):
     self.sp = spark
 
-  def PCA(self, origin_data, k=10):
+  def FE(self, origin_data, k=10):
 
     row = len(origin_data)
     col = len(origin_data[0])
@@ -31,6 +32,7 @@ class SpikeFeatureExtractPCA(object):
     sigma = sigma / row
 
     logging.info ("Start to solve eigen values...")
+    sigma = np.nan_to_num(sigma)
     eig_val, eig_vec = np.linalg.eig (sigma)
     logging.info ("Solve done!")
 

--- a/spike_fe_mllib.py
+++ b/spike_fe_mllib.py
@@ -2,13 +2,14 @@ from pyspark.ml.feature import PCA
 from pyspark.ml.linalg import Vectors
 import numpy as np
 import logging
+from spike_fe_type import SpikeFeatureExtract
 
-class SpikeFeatureExtractPCA_MLLib(object):
+class SpikeFeatureExtractPCA_MLLib(SpikeFeatureExtract):
 
   def __init__(self, spark):
     self.sp = spark
 
-  def PCA(self, origin_data, k=10):
+  def FE(self, origin_data, k=10):
     list_data = [(Vectors.dense(form.tolist()),) for form in origin_data]
 
     data = self.sp.createDataFrame (list_data, ['np_waveforms'])

--- a/spike_fe_type.py
+++ b/spike_fe_type.py
@@ -1,0 +1,17 @@
+
+import logging
+import numpy as np
+
+from pyspark.sql import *
+from pyspark import SparkContext, SparkConf
+from pyspark.sql import functions as F
+from math import sqrt
+
+class SpikeFeatureExtract(object):
+
+  def __init__(self):
+    pass
+
+  @classmethod
+  def FE(self, origin_data, k=10):
+    pass

--- a/spike_main.py
+++ b/spike_main.py
@@ -10,15 +10,38 @@ from pyspark.sql import *
 
 import spike_filter_detect as sp_fd
 
-from spike_cluster_kmeans import SpikeClusterKMeans
 from spike_fe import SpikeFeatureExtractPCA
-from spike_cluster_kmeans_mllib import SpikeClusterKMeans_MLLib
 from spike_fe_mllib import SpikeFeatureExtractPCA_MLLib
+
+from spike_cluster_kmeans import SpikeClusterKMeans
+from spike_cluster_gmm_skl import SpikeClusterGMM_SKL
+from spike_cluster_kmeans_mllib import SpikeClusterKMeans_MLLib
 
 path_root = os.path.dirname(__file__)
 sys.path.append(path_root)
 
 SAMPLE_FREQ = 30000
+
+def FEFactory(InputString, context=None):
+  if(InputString.lower() == "pca"):
+    return SpikeFeatureExtractPCA (context)
+
+  if(InputString.lower() == "mlpca"):
+    return SpikeFeatureExtractPCA_MLLib (context)
+
+  raise Exception("Unsupported Hash Algorithm String %s" % InputString)
+
+def ClusterFactory(InputString, context=None):
+  if(InputString.lower() == "mlkm"):
+    return SpikeClusterKMeans_MLLib(context)
+
+  if(InputString.lower() == "km"):
+    return SpikeClusterKMeans(context)
+
+  if(InputString.lower() == "gmm"):
+    return SpikeClusterGMM_SKL(context)
+
+  raise Exception("Unsupported Hash Algorithm String %s" % InputString)
 
 # Setup import and argument parser
 def path_parse():
@@ -39,7 +62,15 @@ def path_parse():
         )
     parser.add_argument (
         '-c', '--channels', dest = 'Channels', type=int, default=384,
-        help = '''Intervals in seconds to process the data, the bigger, the more accurate'''
+        help = '''Number of channels contained in data file'''
+        )
+    parser.add_argument (
+        '-fe', '--FeatureExtraction', dest = 'FeatureExtraction', type=str, default='pca',
+        help = '''Feature extraction method used for decomposition. Currently supported are 'pca' and 'mlpca'.'''
+        )
+    parser.add_argument (
+        '-cls', '--Cluster', dest = 'ClusterMethod', type=str, default='gmm',
+        help = '''Clustering method used for this sorting. Currently supported are 'km', 'mlkm' and 'gmm'.'''
         )
 
     Paths = parser.parse_args()
@@ -71,12 +102,8 @@ def main ():
   sc.setLogLevel("WARN")
 
   # This is Kun's home brew implementation
-  skm = SpikeClusterKMeans (spark)
-  sfe = SpikeFeatureExtractPCA (spark)
-
-  # # This is purely from spark MLLib
-  # skm = SpikeClusterKMeans_MLLib (spark)
-  # sfe = SpikeFeatureExtractPCA_MLLib (spark)
+  fe_model = FEFactory (Paths.FeatureExtraction, spark)
+  cluster_model = ClusterFactory (Paths.ClusterMethod, spark)
   start_time = 0
 
   with open (Paths.InputFile, 'rb') as input:
@@ -101,13 +128,19 @@ def main ():
         logging.critical ("no spike here, bail this channel for this interval %d." % (chn + 1))
         continue
 
+      if len(wave_form) <= 3:
+        # Less than cluster numbers, bail fast for this interval
+        logging.critical ("Less than cluster numbers, bail fast for this interval %d." % (chn + 1))
+        continue
+
       # Now we are ready to cook. Start from feature extraction
       logging.critical ("Start to process %d waveforms with PCA." % len(wave_form))
-      extracted_wave = sfe.PCA (wave_form)
+      extracted_wave = fe_model.FE (wave_form)
 
       logging.critical ("Done processing PCA!!!")
 
-      clusters = skm.KMeans (extracted_wave, k=3)
+      # clusters = skm.KMeans (extracted_wave, k=3)
+      clusters = cluster_model.Cluster (extracted_wave, k=3)
       logging.critical ("Done clustering!!!")
       for idx in range (3):
         cluster = clusters[idx]

--- a/spike_main.py
+++ b/spike_main.py
@@ -74,7 +74,7 @@ def path_parse():
         )
     parser.add_argument (
         '-cls', '--Cluster', dest = 'ClusterMethod', type=str, default='sklgmm',
-        help = '''Clustering method used for this sorting. Currently supported are 'km', 'mlkm' and 'sklgmm'.'''
+        help = '''Clustering method used for this sorting. Currently supported are 'km', 'mlkm', 'sklkm' and 'sklgmm'.'''
         )
 
     Paths = parser.parse_args()

--- a/spike_main.py
+++ b/spike_main.py
@@ -14,8 +14,9 @@ from spike_fe import SpikeFeatureExtractPCA
 from spike_fe_mllib import SpikeFeatureExtractPCA_MLLib
 
 from spike_cluster_kmeans import SpikeClusterKMeans
-from spike_cluster_gmm_skl import SpikeClusterGMM_SKL
 from spike_cluster_kmeans_mllib import SpikeClusterKMeans_MLLib
+from spike_cluster_kmeans_skl import SpikeClusterKmeans_SKL
+from spike_cluster_gmm_skl import SpikeClusterGMM_SKL
 
 path_root = os.path.dirname(__file__)
 sys.path.append(path_root)
@@ -29,7 +30,7 @@ def FEFactory(InputString, context=None):
   if(InputString.lower() == "mlpca"):
     return SpikeFeatureExtractPCA_MLLib (context)
 
-  raise Exception("Unsupported Hash Algorithm String %s" % InputString)
+  raise Exception("Unsupported Feature Extration String %s" % InputString)
 
 def ClusterFactory(InputString, context=None):
   if(InputString.lower() == "mlkm"):
@@ -38,10 +39,13 @@ def ClusterFactory(InputString, context=None):
   if(InputString.lower() == "km"):
     return SpikeClusterKMeans(context)
 
-  if(InputString.lower() == "slkgmm"):
+  if(InputString.lower() == "sklgmm"):
     return SpikeClusterGMM_SKL(context)
 
-  raise Exception("Unsupported Hash Algorithm String %s" % InputString)
+  if(InputString.lower() == "sklkm"):
+    return SpikeClusterKmeans_SKL(context)
+
+  raise Exception("Unsupported Clustering String %s" % InputString)
 
 # Setup import and argument parser
 def path_parse():
@@ -69,8 +73,8 @@ def path_parse():
         help = '''Feature extraction method used for decomposition. Currently supported are 'pca' and 'mlpca'.'''
         )
     parser.add_argument (
-        '-cls', '--Cluster', dest = 'ClusterMethod', type=str, default='slkgmm',
-        help = '''Clustering method used for this sorting. Currently supported are 'km', 'mlkm' and 'slkgmm'.'''
+        '-cls', '--Cluster', dest = 'ClusterMethod', type=str, default='sklgmm',
+        help = '''Clustering method used for this sorting. Currently supported are 'km', 'mlkm' and 'sklgmm'.'''
         )
 
     Paths = parser.parse_args()

--- a/spike_main.py
+++ b/spike_main.py
@@ -38,7 +38,7 @@ def ClusterFactory(InputString, context=None):
   if(InputString.lower() == "km"):
     return SpikeClusterKMeans(context)
 
-  if(InputString.lower() == "gmm"):
+  if(InputString.lower() == "slkgmm"):
     return SpikeClusterGMM_SKL(context)
 
   raise Exception("Unsupported Hash Algorithm String %s" % InputString)
@@ -69,8 +69,8 @@ def path_parse():
         help = '''Feature extraction method used for decomposition. Currently supported are 'pca' and 'mlpca'.'''
         )
     parser.add_argument (
-        '-cls', '--Cluster', dest = 'ClusterMethod', type=str, default='gmm',
-        help = '''Clustering method used for this sorting. Currently supported are 'km', 'mlkm' and 'gmm'.'''
+        '-cls', '--Cluster', dest = 'ClusterMethod', type=str, default='slkgmm',
+        help = '''Clustering method used for this sorting. Currently supported are 'km', 'mlkm' and 'slkgmm'.'''
         )
 
     Paths = parser.parse_args()


### PR DESCRIPTION
Move Clustering and Feature Extraction models into factory selectors.

It also added a sklearn based k-means clustering. But its performance is not as good as sklearn GMM or home brew K-Means. Thus not selected as default.

Support `-cls` for selecting clustering methods. Currently support (first as default): `sklgmm`, `km`, `mlkm`, `sklkm`.
Support `-fe` for selecting feature extraction methods. Currently support (first as default): `pca`, `mlpca`.